### PR TITLE
Create CODEOWNERS for auto-assigning reviewers

### DIFF
--- a/.github  /CODEOWNERS
+++ b/.github  /CODEOWNERS
@@ -1,0 +1,2 @@
+# Auto-assign PRs to reviewers team
+* @EndToEndLabCR/reviewers


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

This pull request makes a small update to the `.github/CODEOWNERS` file to improve pull request review assignment. The change ensures that all PRs are automatically assigned to the `@EndToEndLabCR/reviewers` team for review.
