### PR TITLE
Forgot Password Page Implementation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,12 +16,14 @@ function App() {
   const location = useLocation();
   const isLogin = location.pathname === "/login";
   const isRegister = location.pathname === "/register";
+  const isForgetPassword = location.pathname === "/forget-password";
 
   return (
     <Layout style={{ minHeight: "100vh" }}>
-      {!isLogin && !isRegister && <SiderMenu />}   
+      {!isLogin && !isRegister && !isForgetPassword && <SiderMenu />}
+      {}   
       <Layout>
-        {!isLogin && !isRegister && <AppHeader />} 
+        {!isLogin && !isRegister && !isForgetPassword && <AppHeader />} 
 
         <Content style={{ margin: "24px 16px 0" }}>
           <div
@@ -36,7 +38,7 @@ function App() {
           </div>
         </Content>
 
-        {!isLogin && !isRegister && <AppFooter />}
+        {!isLogin && !isRegister && !isForgetPassword && <AppFooter />}
       </Layout>
     </Layout>
   );

--- a/src/features/forget-password/ForgetPassword.scss
+++ b/src/features/forget-password/ForgetPassword.scss
@@ -1,0 +1,156 @@
+.forget-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-color: #121212;
+  padding: 40px;
+}
+
+/* CARD */
+.forget-card,
+.ant-card.forget-card {
+  background-color: #2A2A2A;
+  border-radius: 12px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.55);
+  color: #f5f5f5;
+  
+  .ant-card-head {
+    background: #2A2A2A;
+    border-bottom: 1px solid #3a3a3a;
+    border-radius: 12px 12px 0 0;
+  }
+
+  .ant-input-affix-wrapper {
+  width: 80%;
+  margin: 12px auto 0;
+  }
+
+  .ant-card-head-title {
+    color: #fff;
+    font-size: 20px;
+    font-weight: 700;
+    text-align: center;
+  }
+
+.forget-form .ant-form-item .ant-form-item-explain,
+.forget-form .ant-form-item .ant-form-item-explain-error {
+  width: 80%;
+  margin: 6px auto 0;
+  text-align: center;
+}
+
+}
+
+/* FORM */
+.forget-form {
+  color: #f5f5f5;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .ant-form-item {
+    width: 80%;
+  }
+
+  .ant-form-item-label > label {
+    color: #cfcfcf;
+    font-weight: 500;
+    width: 100%;
+  display: flex;
+  justify-content: center;
+  }
+
+  .ant-form-item-control-input-content {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+  }
+
+.forget-form .ant-input-affix-wrapper {
+  width: 80% !important;
+}
+
+  /* INPUTS */
+  .ant-input-affix-wrapper {
+    width: 80%;
+    background-color: #1e1e1e;
+    border: 1px solid #333;
+    border-radius: 8px;
+    height: 44px;
+    color: #f5f5f5;
+    transition: all 0.25s ease;
+    width: 80% !important;
+    margin: 0 auto;
+
+    &:hover,
+    &:focus,
+    &.ant-input-affix-wrapper-focused,
+    &:focus-within {
+      border-color: #BB86FC;
+      box-shadow: 0 0 0 3px rgba(187, 134, 252, 0.2);
+    }
+  }
+
+  .ant-input {
+    background: transparent;
+    color: #f5f5f5;
+
+    &::placeholder {
+      color: #b0b0b0;
+      font-size: 13px;
+    }
+  }
+}
+
+.ant-input-password-icon,
+.ant-input-clear-icon {
+  svg {
+    fill: #f5f5f5 !important;
+    cursor: pointer;
+    transition: fill 0.2s;
+  }
+}
+
+.ant-input-password-icon:hover,
+.ant-input-clear-icon:hover {
+  svg {
+    fill: #BB86FC !important;
+  }
+}
+
+/* BUTTON */
+.forget-form-button {
+  background-color: #BB86FC;
+  border: none;
+  height: 44px;
+  font-weight: 600;
+  border-radius: 10px;
+  margin-top: 8px;
+  transition: transform 0.15s ease, box-shadow 0.25s ease, background-color 0.25s ease;
+
+  &:hover {
+    background-color: #a56efc !important;
+    transform: translateY(-1px);
+    box-shadow: 0 8px 18px rgba(187, 134, 252, 0.35);
+  }
+}
+
+/* LINKS */
+.forget-link {
+  margin-top: 14px;
+  text-align: center;
+
+  a {
+    color: #BB86FC;
+    margin: 0 30px;
+    font-size: 13px;
+    transition: color 0.2s;
+
+    &:hover {
+      color: #d1a9ff;
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/features/forget-password/ForgetPassword.tsx
+++ b/src/features/forget-password/ForgetPassword.tsx
@@ -1,0 +1,45 @@
+import { MailOutlined } from "@ant-design/icons";
+import { Button, Card, Form, Input } from "antd";
+import "./ForgetPassword.scss";
+
+
+export function ForgetPassword() {
+    return (
+       <div className="forget-container">
+        <Card title="Forgot your password?" bordered={false} className="forget-card">
+        <Form className="forget-form" layout="vertical" colon={false}> 
+            <Form.Item
+            label="Please enter the email address you´d like your password reset information sent to"
+            name="email"
+            rules={[{ required: true, message: "Please input your email!" }]}
+            >
+            < Input className="forget-form-input"
+              size="large"
+              allowClear
+              prefix={<MailOutlined />}
+              placeholder="Email"
+            />
+          </Form.Item>
+
+          <Form.Item>
+            <Button
+              className="forget-form-button"
+              type="primary"
+              htmlType="submit"
+              size="large"
+            >
+              Request Reset Link
+            </Button>
+          </Form.Item>
+          
+          </Form>
+          <div className="forget-link">
+            <p>
+              <a href="/login">Back to Login</a>
+            </p>
+          </div>
+          </Card>
+          </div>
+    );
+    
+}

--- a/src/features/login/Login.tsx
+++ b/src/features/login/Login.tsx
@@ -40,7 +40,7 @@ export function Login() {
 
           <div className="login-links">
             <a href="/register">Sign In</a> &nbsp; 
-            <a href="#">Forgot Password?</a>
+            <a href="/forget-password">Forgot Password?</a>
           </div>
         </Form>
       </Card>

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -8,6 +8,7 @@ import { Week } from "../features/calendar/week/Week";
 import { Home } from "../features/home/Home";
 import { Login } from "../features/login/Login";
 import { Register } from "../features/register/Register";
+import { ForgetPassword } from "../features/forget-password/ForgetPassword";
 import { Settings } from "../features/more/settings/Settings";
 import { Personal } from "../features/projects/personal/Personal";
 import { University } from "../features/projects/university/University";
@@ -24,6 +25,9 @@ export function AppRoutes() {
 
       {/* Register */}
       <Route path="/register" element={<Register />} />
+
+      {/* Forget Password */}
+      <Route path="/forget-password" element={<ForgetPassword />} />
 
       {/* Calendar */}
       <Route path="/calendar/today" element={<Today />} />


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

This PR adds the new "Forgot Password" screen following the same style and structure as the Login and Register pages. It includes the route, TSX component, and SCSS styles.

### Changes by file

- src/routes/AppRoutes.tsx
  • Added the `/forgot-password` route to render the ForgotPassword component.

- src/App.tsx
  • Reused the `useLocation` hook (react-router-dom) to detect the current URL.
  • When the route is `/forgot-password`, the main layout is hidden.

- src/features/forgot-password/ForgetPassword.tsx
  • Created the form using the same Ant Design components as Login and Register:
    - Email input field
    - Request reset button
    - Card with consistent styling

- src/features/forgot-password/ForgetPassword.scss
  • Styles for the Forgot Password form, matching colors and layout from Login/Register.
  • Includes container, card, input fields, and button.

### Result
The application now includes a fully styled Forgot Password page accessible at `/forgot-password`, maintaining visual consistency with Login and Register, and conditional layout rendering.

---

## 📸 Screenshots 
<img width="1346" height="768" alt="image" src="https://github.com/user-attachments/assets/76100518-2749-46ea-829b-eddffad13d10" />

---